### PR TITLE
Fix wrong bit order for bottom-aslr and force relocate images

### DIFF
--- a/NtApiDotNet/NtProcessMitigations.cs
+++ b/NtApiDotNet/NtProcessMitigations.cs
@@ -28,8 +28,8 @@ namespace NtApiDotNet
             DepPermanent = dep_status.Permanent;
                     
             int result = process.GetProcessMitigationPolicy(ProcessMitigationPolicy.ProcessASLRPolicy);
-            EnableForceRelocateImages = result.GetBit(0);
-            EnableBottomUpRandomization = result.GetBit(1);
+            EnableBottomUpRandomization = result.GetBit(0);
+            EnableForceRelocateImages = result.GetBit(1);
             EnableHighEntropy = result.GetBit(2);
             DisallowStrippedImages = result.GetBit(3);
 


### PR DESCRIPTION
After seeing different results for the ASLR policy from this tool and https://github.com/fishstiqz/mitigationview, it seems that the order of the bits is mixed up.

The returned int value from GetProcessMitigationPolicy() is 5, which is 0101 in binary. This patch should fix the order.