### PR TITLE
Parse out reparse guid in the generic reparse point structure

### DIFF
--- a/NtApiDotNet/NtFile.cs
+++ b/NtApiDotNet/NtFile.cs
@@ -1079,6 +1079,8 @@ namespace NtApiDotNet
         {
         }
 
+        public Guid Guid { get; private set; }
+
         public byte[] Data { get; private set; }
 
         protected override byte[] GetBuffer()
@@ -1088,6 +1090,7 @@ namespace NtApiDotNet
 
         protected override void ParseBuffer(int data_length, BinaryReader reader)
         {
+            Guid = new Guid(reader.ReadAllBytes(16));
             Data = reader.ReadAllBytes(data_length);
         }
     }


### PR DESCRIPTION
The ReparseGuid in the REPARSE_GUID_DATA_BUFFER was not parsed out.

https://msdn.microsoft.com/en-us/library/windows/desktop/aa365500(v=vs.85).aspx

I've signed the CLA.