### PR TITLE
Added missing values for file attributes (used by OneDrive local files)

### DIFF
--- a/NtApiDotNet/NtFile.cs
+++ b/NtApiDotNet/NtFile.cs
@@ -334,6 +334,9 @@ namespace NtApiDotNet
         Virtual = 0x00010000,
         NoScrubData = 0x00020000,
         Ea = 0x00040000,
+        Pinned = 0x00080000,
+        Unpinned = 0x00100000,
+        RecallOnDataAccess = 0x00400000,
     }
 
     [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
Make NtFile::FileAttributes display decoded file attributes for OneDrive local files.
These attributes are valid starting from Windows 10 RS2 (as stated in the WDK headers).