### PR TITLE
NdrBaseArray.FormatType should print out array element count, not siz

### DIFF
--- a/NtApiDotNet/Ndr/NdrTypes.cs
+++ b/NtApiDotNet/Ndr/NdrTypes.cs
@@ -632,7 +632,10 @@ namespace NtApiDotNet.Ndr
         internal override string FormatType(NdrFormatter context)
         {
             int array_size = GetArraySize();
-            return String.Format("{0}[{1}]", ElementType.FormatType(context), array_size == 0 ? String.Empty : array_size.ToString());
+            int element_size = ElementType.GetSize();
+            int array_count = (element_size != 0) ? array_size / element_size : array_size;
+
+            return String.Format("{0}[{1}]", ElementType.FormatType(context), array_size == 0 ? String.Empty : array_count.ToString());
         }
     }
 


### PR DESCRIPTION
Currently the string format for array types return the array size
between brackets. It should return the array element count instead.

Before :
```
HRESULT Proc0(
    /* Stack Offset: 0 */ handle_t p0, 
    /* Stack Offset: 8 */ [In, Out] wchar_t[520] p1
);
```

After :
```
HRESULT Proc0(
    /* Stack Offset: 0 */ handle_t p0, 
    /* Stack Offset: 8 */ [In, Out] wchar_t[260] p1
);
```