### PR TITLE
Fix DepStatus On Windows Server 2K12 / 2K16. On those OSes, the API N…

### DIFF
--- a/NtApiDotNet/NtProcess.cs
+++ b/NtApiDotNet/NtProcess.cs
@@ -1503,6 +1503,13 @@ namespace NtApiDotNet
                         {
                             status.ToNtException();
                         }
+                        else if (Is64Bit)
+                        {
+                            // On 64 bits OS, DEP is always ON for 64 bits processes
+                            ret.Enabled = true;
+                            ret.Permanent = true;
+                        }
+
                         return ret;
                     }
 


### PR DESCRIPTION
Fixed DepStatus on OS servers where Dep was set to 'false' for 64 bits processes